### PR TITLE
Fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -5944,7 +5944,7 @@ Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_de-DE.md
+++ b/README_de-DE.md
@@ -5944,7 +5944,7 @@ Lizenziert unter [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Star-Verlauf
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_es-419.md
+++ b/README_es-419.md
@@ -5944,7 +5944,7 @@ Licenciado bajo [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Historial de estrellas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_es-ES.md
+++ b/README_es-ES.md
@@ -5944,7 +5944,7 @@ Licenciado bajo [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Historial de estrellas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_fr-FR.md
+++ b/README_fr-FR.md
@@ -5944,7 +5944,7 @@ Sous licence [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Historique des étoiles
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_hi-IN.md
+++ b/README_hi-IN.md
@@ -5944,7 +5944,7 @@ The gallery features:
 
 ## ⭐ स्टार इतिहास
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_it-IT.md
+++ b/README_it-IT.md
@@ -5944,7 +5944,7 @@ Concesso in licenza sotto [CC BY 4.0](https://creativecommons.org/licenses/by/4.
 
 ## ⭐ Cronologia stelle
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_ja-JP.md
+++ b/README_ja-JP.md
@@ -5946,7 +5946,7 @@ The gallery features:
 
 ## ⭐ スター履歴
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_ko-KR.md
+++ b/README_ko-KR.md
@@ -5944,7 +5944,7 @@ The gallery features:
 
 ## ⭐ 스타 히스토리
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_pt-BR.md
+++ b/README_pt-BR.md
@@ -5944,7 +5944,7 @@ Licenciado sob [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Histórico de estrelas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_pt-PT.md
+++ b/README_pt-PT.md
@@ -5943,7 +5943,7 @@ Licenciado sob [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
 ## ⭐ Histórico de estrelas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_th-TH.md
+++ b/README_th-TH.md
@@ -5946,7 +5946,7 @@ The gallery features:
 
 ## ⭐ ประวัติดาว
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_tr-TR.md
+++ b/README_tr-TR.md
@@ -5944,7 +5944,7 @@ Detaylı yönergeler için [CONTRIBUTING.md](docs/CONTRIBUTING.md) dosyasına ba
 
 ## ⭐ Yıldız Geçmişi
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_vi-VN.md
+++ b/README_vi-VN.md
@@ -5944,7 +5944,7 @@ Xem [CONTRIBUTING.md](docs/CONTRIBUTING.md) để biết hướng dẫn chi ti�
 
 ## ⭐ Lịch sử sao
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -5946,7 +5946,7 @@ The gallery features:
 
 ## ⭐ Star 歷史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -5946,7 +5946,7 @@ The gallery features:
 
 ## ⭐ Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 

--- a/scripts/utils/markdown-generator.ts
+++ b/scripts/utils/markdown-generator.ts
@@ -443,7 +443,7 @@ ${t('licensedUnder', locale)}
 
 ## ⭐ ${t('starHistory', locale)}
 
-[![Star History Chart](https://api.star-history.com/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.com/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=YouMind-OpenLab/awesome-nano-banana-pro-prompts&type=Date)](https://star-history.dera.page/#YouMind-OpenLab/awesome-nano-banana-pro-prompts&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart on the READMEs is currently broken because of GitHub stargazer API restrictions, so it fails to render for anyone visiting the repository. This change switches the chart to a working alternative that uses a different data source and requires no API token, restoring the chart. The chart image and its wrapping link were updated across the main README, all localized READMEs, and the generator template so they stay consistent on future auto-updates.